### PR TITLE
Add message buttons

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+web: npm run web
 worker: npm start

--- a/adapter-repl.js
+++ b/adapter-repl.js
@@ -1,0 +1,10 @@
+var conf = require('./config');
+
+var SlackAdapter = require('./src/slack-adapter');
+
+var SlackClient = require('slack-client');
+
+var client = new SlackClient(conf.get('slackToken'));
+var adapter = new SlackAdapter(client);
+
+module.exports = adapter;

--- a/attributes/manness.json
+++ b/attributes/manness.json
@@ -11,7 +11,8 @@
       ],
       "texts": {
         "information": "you are not a man",
-        "update": "Okay, we have noted that you are not a man. If I got it wrong, try saying “I am a man”.",
+        "update": "Okay, we have noted that you are not a man.",
+        "wrong": "If I got it wrong, try saying “I am a man”.",
         "statistics": "notMen",
         "table": "not-men",
         "terse": "not-men",
@@ -28,7 +29,8 @@
       ],
       "texts": {
         "information": "you are a man",
-        "update": "Okay, we have noted that you are a man. If I got it wrong, try saying “I am *not* a man!”",
+        "update": "Okay, we have noted that you are a man. ",
+        "wrong": "If I got it wrong, try saying “I am *not* a man!”",
         "statistics": "men",
         "table": "men",
         "short": "M",

--- a/attributes/manness.json
+++ b/attributes/manness.json
@@ -3,6 +3,23 @@
   "interviewQuestion": "Are you a man?",
   "values": [
     {
+      "value": "a man",
+      "matcherSets": [
+        [{"matches": "true"}],
+        [{"matches": "man"}, {"doesNotMatch": "not"}, {"doesNotMatch": "woman"}],
+        [{"matches": "woman"}, {"matches": "not"}]
+      ],
+      "texts": {
+        "information": "you are a man",
+        "update": "Okay, we have noted that you are a man. ",
+        "wrong": "If I got it wrong, try saying “I am *not* a man!”",
+        "statistics": "men",
+        "table": "men",
+        "short": "M",
+        "interviewAnswer": "Yes"
+      }
+    },
+    {
       "value": "not a man",
       "matcherSets": [
         [{"matches": "false"}],
@@ -18,23 +35,6 @@
         "terse": "not-men",
         "short": "NM",
         "interviewAnswer": "No"
-      }
-    },
-    {
-      "value": "a man",
-      "matcherSets": [
-        [{"matches": "true"}],
-        [{"matches": "man"}, {"doesNotMatch": "not"}, {"doesNotMatch": "woman"}],
-        [{"matches": "woman"}, {"matches": "not"}]
-      ],
-      "texts": {
-        "information": "you are a man",
-        "update": "Okay, we have noted that you are a man. ",
-        "wrong": "If I got it wrong, try saying “I am *not* a man!”",
-        "statistics": "men",
-        "table": "men",
-        "short": "M",
-        "interviewAnswer": "Yes"
       }
     },
     {

--- a/attributes/manness.json
+++ b/attributes/manness.json
@@ -17,7 +17,7 @@
         "table": "not-men",
         "terse": "not-men",
         "short": "NM",
-        "interviewAnswer": "Yes"
+        "interviewAnswer": "No"
       }
     },
     {
@@ -34,7 +34,7 @@
         "statistics": "men",
         "table": "men",
         "short": "M",
-        "interviewAnswer": "No"
+        "interviewAnswer": "Yes"
       }
     },
     {

--- a/attributes/manness.json
+++ b/attributes/manness.json
@@ -1,5 +1,6 @@
 {
   "name": "manness",
+  "interviewQuestion": "Are you a man?",
   "values": [
     {
       "value": "not a man",
@@ -14,7 +15,8 @@
         "statistics": "notMen",
         "table": "not-men",
         "terse": "not-men",
-        "short": "NM"
+        "short": "NM",
+        "interviewAnswer": "Yes"
       }
     },
     {
@@ -29,7 +31,8 @@
         "update": "Okay, we have noted that you are a man. If I got it wrong, try saying “I am *not* a man!”",
         "statistics": "men",
         "table": "men",
-        "short": "M"
+        "short": "M",
+        "interviewAnswer": "No"
       }
     },
     {
@@ -43,7 +46,8 @@
         "update": "We have noted that it’s complicated whether you are a man. If I got it wrong, try saying “I am not a man.”",
         "statistics": "complicated",
         "table": "complicated",
-        "short": "‽"
+        "short": "‽",
+        "interviewAnswer": "It’s complicated"
       }
     },
     {
@@ -57,7 +61,8 @@
         "update": "Okay, we have erased our record of whether you are a man.",
         "statistics": "unknown",
         "table": "unknown",
-        "short": "?"
+        "short": "?",
+        "interviewAnswer": "Decline"
       }
     }
   ],

--- a/attributes/pocness.json
+++ b/attributes/pocness.json
@@ -1,5 +1,6 @@
 {
   "name": "pocness",
+  "interviewQuestion": "Are you a person of colour?",
   "values": [
     {
       "value": "a PoC",
@@ -13,7 +14,8 @@
         "statistics": "peopleOfColour",
         "table": "PoC",
         "terse": "people of colour",
-        "short": "PoC"
+        "short": "PoC",
+        "interviewAnswer": "Yes"
       }
     },
     {
@@ -27,7 +29,8 @@
         "update": "We have noted that you are not a person of colour. If I got it wrong, try saying “I am a person of colour”",
         "statistics": "nonPeopleOfColour",
         "table": "not-PoC",
-        "short": "N"
+        "short": "N",
+        "interviewAnswer": "No"
       }
     },
     {
@@ -41,7 +44,8 @@
         "update": "We have noted that it’s complicated whether you are a person of colour. If I got it wrong, try saying “I am a person of colour”",
         "statistics": "complicated",
         "table": "complicated",
-        "short": "‽"
+        "short": "‽",
+        "interviewAnswer": "It’s complicated"
       }
     },
     {
@@ -55,7 +59,8 @@
         "update": "We have erased our record of whether you are a person of colour.",
         "statistics": "unknown",
         "table": "unknown",
-        "short": "?"
+        "short": "?",
+        "interviewAnswer": "Decline"
       }
     }
   ],

--- a/attributes/pocness.json
+++ b/attributes/pocness.json
@@ -10,7 +10,8 @@
       ],
       "texts": {
         "information": "you are a person of colour",
-        "update": "We have noted that you are a person of colour. If I got it wrong, try saying “I am not a person of colour”",
+        "update": "We have noted that you are a person of colour.",
+        "wrong": "If I got it wrong, try saying “I am not a person of colour”",
         "statistics": "peopleOfColour",
         "table": "PoC",
         "terse": "people of colour",
@@ -26,7 +27,8 @@
       ],
       "texts": {
         "information": "you are not a person of colour",
-        "update": "We have noted that you are not a person of colour. If I got it wrong, try saying “I am a person of colour”",
+        "update": "We have noted that you are not a person of colour.",
+        "wrong": "If I got it wrong, try saying “I am a person of colour”",
         "statistics": "nonPeopleOfColour",
         "table": "not-PoC",
         "short": "N",
@@ -41,7 +43,8 @@
       ],
       "texts": {
         "information": "it’s complicated whether you are a person of colour",
-        "update": "We have noted that it’s complicated whether you are a person of colour. If I got it wrong, try saying “I am a person of colour”",
+        "update": "We have noted that it’s complicated whether you are a person of colour.",
+        "wrong": "If I got it wrong, try saying “I am a person of colour”",
         "statistics": "complicated",
         "table": "complicated",
         "short": "‽",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node --use-strict index.js",
     "debug": "node debug --use-strict index.js",
-    "test": "tap --strict test/*"
+    "test": "tap --strict test/*",
+    "web": "node --use-strict web.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-tape": "0.0.2",
+    "nock": "^8.0.0",
     "require-subvert": "^0.1.0",
     "sinon": "^1.12.2",
     "supertest-koa-agent": "^0.2.1",
@@ -51,6 +52,7 @@
     "sequelize": "^3.21.0",
     "sequelize-cli": "1.1.0",
     "slack-client": "^1.3.1",
+    "superagent": "^2.1.0",
     "tap": "^0.5.0",
     "validator": "^3.28.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "convict": "^0.6.1",
     "cron-parser": "^0.6.1",
     "koa": "^1.2.0",
+    "koa-body": "^1.4.0",
     "koa-router": "^5.4.0",
     "lodash.every": "^3.2.0",
     "lodash.find": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,15 @@
     "grunt-tape": "0.0.2",
     "require-subvert": "^0.1.0",
     "sinon": "^1.12.2",
+    "supertest-koa-agent": "^0.2.1",
     "tape": "^3.4.0"
   },
   "dependencies": {
     "cli-table": "^0.3.1",
     "convict": "^0.6.1",
     "cron-parser": "^0.6.1",
+    "koa": "^1.2.0",
+    "koa-router": "^5.4.0",
     "lodash.every": "^3.2.0",
     "lodash.find": "^3.2.0",
     "lodash.map": "^3.1.4",

--- a/src/direct-message-handler.js
+++ b/src/direct-message-handler.js
@@ -20,7 +20,7 @@ class DirectMessageHandler {
 
   handle(channel, message) {
     if (!message.text || message.subtype === 'bot_message') return;
-    var text = message.text.toLowerCase();
+    var text = message.text.toLowerCase().trim();
 
     var user = this.adapter.getUser(message.user);
 

--- a/src/direct-message-handler.js
+++ b/src/direct-message-handler.js
@@ -31,7 +31,6 @@ class DirectMessageHandler {
         attachments: [{
           title: 'Would you like to self-identify?',
           callback_id: 'initial',
-          color: '#ccc',
           attachment_type: 'default',
           actions: [
             {

--- a/src/direct-message-handler.js
+++ b/src/direct-message-handler.js
@@ -131,7 +131,7 @@ class DirectMessageHandler {
     });
 
     if (matchingValue) {
-      reply = matchingValue.texts.update;
+      reply = `${matchingValue.texts.update} ${matchingValue.texts.wrong || ''}`;
     }
 
     channel.send(reply);

--- a/src/direct-message-handler.js
+++ b/src/direct-message-handler.js
@@ -24,7 +24,36 @@ class DirectMessageHandler {
 
     var user = this.adapter.getUser(message.user);
 
-    if (text === 'info') {
+    // TODO replace the self-identification request with this
+    if (text === 'interview') {
+      channel.postMessage({
+        text: DirectMessageHandler.INTERVIEW_INTRODUCTION,
+        attachments: [{
+          title: 'Would you like to self-identify?',
+          callback_id: 'initial',
+          color: '#ccc',
+          attachment_type: 'default',
+          actions: [
+            {
+              name: 'yes',
+              text: 'Yes',
+              type: 'button',
+              value: 'yes'
+            }, {
+              name: 'no',
+              text: 'No',
+              type: 'button',
+              value: 'no'
+            }, {
+              name: 'more',
+              text: 'Tell me more',
+              type: 'button',
+              value: 'more'
+            }
+          ]
+        }]
+      });
+    } else if (text === 'info') {
       this.handleInformationRequest(channel, message);
     } else if (text === 'help') {
       this.handleHelpRequest(channel, message);
@@ -179,6 +208,7 @@ class DirectMessageHandler {
 // TODO maybe messages should be collected somewhere central, and parameterised
 
 DirectMessageHandler.HELP_MESSAGE = 'You can let me know “I’m not a man”, “I am a person of colour”, “it’s complicated whether I am white” and other such variations, or ask for my current information on you with “info”. View my source at https://github.com/backspace/slack-statsbot';
-DirectMessageHandler.VERBOSE_HELP_MESSAGE = `Hey, I’m a bot that collects statistics on who is taking up space in the channels I’m in. For now, I only track whether or not a participant is a man and/or a person of colour. ${DirectMessageHandler.HELP_MESSAGE}`;
+DirectMessageHandler.INTERVIEW_INTRODUCTION = 'Hey, I’m a bot that collects statistics on who is taking up space in the channels I’m in. For now, I only track whether or not a participant is a man and/or a person of colour.';
+DirectMessageHandler.VERBOSE_HELP_MESSAGE = `${DirectMessageHandler.INTERVIEW_INTRODUCTION} ${DirectMessageHandler.HELP_MESSAGE}`;
 
 module.exports = DirectMessageHandler;

--- a/src/direct-message-handler.js
+++ b/src/direct-message-handler.js
@@ -185,7 +185,7 @@ class DirectMessageHandler {
 // TODO maybe messages should be collected somewhere central, and parameterised
 
 DirectMessageHandler.HELP_MESSAGE = 'You can let me know “I’m not a man”, “I am a person of colour”, “it’s complicated whether I am white” and other such variations, or ask for my current information on you with “info”. View my source at https://github.com/backspace/slack-statsbot';
-DirectMessageHandler.INTERVIEW_INTRODUCTION = 'Hey, I’m a bot that collects statistics on who is taking up space in the channels I’m in. For now, I only track whether or not a participant is a man and/or a person of colour.';
+DirectMessageHandler.INTERVIEW_INTRODUCTION = 'Hey, I’m a bot that collects statistics on who is taking up space in the channels I’m in. For now, I only track whether or not a participant is a man and/or a person of colour. If you feel comfortable answering questions about this, we can continue.';
 DirectMessageHandler.VERBOSE_HELP_MESSAGE = `${DirectMessageHandler.INTERVIEW_INTRODUCTION} ${DirectMessageHandler.HELP_MESSAGE}`;
 
 module.exports = DirectMessageHandler;

--- a/src/message-buttons/question-for-attribute-configuration.js
+++ b/src/message-buttons/question-for-attribute-configuration.js
@@ -3,7 +3,6 @@ module.exports = function questionForAttributeConfiguration(attributeConfigurati
   return {
     title: attributeConfiguration.interviewQuestion,
     callback_id: attributeConfiguration.name,
-    color: '#ccc',
     attachment_type: 'default',
     actions: attributeConfiguration.values.map(value => {
       return {

--- a/src/message-buttons/question-for-attribute-configuration.js
+++ b/src/message-buttons/question-for-attribute-configuration.js
@@ -1,20 +1,17 @@
 
 module.exports = function questionForAttributeConfiguration(attributeConfiguration) {
-  return {
-    text: attributeConfiguration.interviewQuestion,
-    attachments: [{
-      title: attributeConfiguration.interviewQuestion,
-      callback_id: attributeConfiguration.name,
-      color: '#ccc',
-      attachment_type: 'default',
-      actions: attributeConfiguration.values.map(value => {
-        return {
-          name: attributeConfiguration.name,
-          text: value.texts.interviewAnswer,
-          type: 'button',
-          value: value.value || 'decline'
-        };
-      })
-    }]
-  };
+  return [{
+    title: attributeConfiguration.interviewQuestion,
+    callback_id: attributeConfiguration.name,
+    color: '#ccc',
+    attachment_type: 'default',
+    actions: attributeConfiguration.values.map(value => {
+      return {
+        name: attributeConfiguration.name,
+        text: value.texts.interviewAnswer,
+        type: 'button',
+        value: value.value || 'decline'
+      };
+    })
+  }];
 }

--- a/src/message-buttons/question-for-attribute-configuration.js
+++ b/src/message-buttons/question-for-attribute-configuration.js
@@ -1,0 +1,20 @@
+
+module.exports = function questionForAttributeConfiguration(attributeConfiguration) {
+  return {
+    text: attributeConfiguration.interviewQuestion,
+    attachments: [{
+      title: attributeConfiguration.interviewQuestion,
+      callback_id: attributeConfiguration.name,
+      color: '#ccc',
+      attachment_type: 'default',
+      actions: attributeConfiguration.values.map(value => {
+        return {
+          name: attributeConfiguration.name,
+          text: value.texts.interviewAnswer,
+          type: 'button',
+          value: value.value || 'decline'
+        };
+      })
+    }]
+  };
+}

--- a/src/message-buttons/question-for-attribute-configuration.js
+++ b/src/message-buttons/question-for-attribute-configuration.js
@@ -1,6 +1,6 @@
 
 module.exports = function questionForAttributeConfiguration(attributeConfiguration) {
-  return [{
+  return {
     title: attributeConfiguration.interviewQuestion,
     callback_id: attributeConfiguration.name,
     color: '#ccc',
@@ -13,5 +13,5 @@ module.exports = function questionForAttributeConfiguration(attributeConfigurati
         value: value.value || 'decline'
       };
     })
-  }];
+  };
 }

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -28,6 +28,8 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
 
     if (attributeName === 'initial') {
       if (action.value === 'yes') {
+        this.status = 200;
+
         request.post(payload.response_url).send({
           text: DirectMessageHandler.INTERVIEW_INTRODUCTION,
           attachments: [{
@@ -60,6 +62,8 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
       const nextAttributeConfiguration = getNextAttributeConfiguration(attributeConfigurations, attributeName);
 
       if (nextAttributeConfiguration) {
+        this.status = 200;
+
         request.post(payload.response_url).send({
           attachments: [{
             title: responseAttributeConfiguration.interviewQuestion,
@@ -78,6 +82,8 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
           userRepository: userRepository,
           attributeConfigurations: attributeConfigurations
         }).then(reply => {
+          this.status = 200;
+
           request.post(payload.response_url).send({
             attachments: [{
               title: responseAttributeConfiguration.interviewQuestion,

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -1,12 +1,23 @@
 const koa = require('koa');
 const Router = require('koa-router');
 
+const bodyParser = require('koa-body');
+
 module.exports = function() {
   const app = koa();
+  app.use(bodyParser());
+
   const router = new Router();
 
   router.post('/slack/actions', function* (next) {
-    this.body = 'Aww!';
+    const payload = JSON.parse(this.request.body.payload);
+    const action = payload.actions[0];
+
+    if (action.value === 'more') {
+      this.body = 'Here is more information.';
+    } else {
+      this.body = 'Aww!';
+    }
 
     yield next;
   });

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -64,7 +64,12 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
             code: this.request.query.code
           })
           .end((err, res) => {
-            this.body = {test: res.body.bot.bot_access_token};
+            if (res.body.ok) {
+              this.body = {test: res.body.bot.bot_access_token};
+            } else {
+              this.body = {error: res.body.error};
+            }
+
             resolve();
           });
       });

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -16,19 +16,28 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
 
     if (attributeName === 'initial') {
       if (action.value === 'yes') {
-        this.body = questionForAttributeConfiguration(attributeConfigurations[0]);
+        this.body = {
+          text: 'Here is the first question???',
+          attachments: questionForAttributeConfiguration(attributeConfigurations[0])
+        };
       } else if (action.value === 'more') {
         this.body = 'Here is more information.';
       } else {
         this.body = 'Aww!';
       }
     } else {
+      const responseAttributeConfiguration = attributeConfigurations.find(configuration => configuration.name === attributeName);
+      const responseAttributeValue = responseAttributeConfiguration.values.find(attributeValue => attributeValue.value === action.value);
+
       const nextAttributeConfiguration = getNextAttributeConfiguration(attributeConfigurations, attributeName);
 
       if (nextAttributeConfiguration) {
-        this.body = questionForAttributeConfiguration(nextAttributeConfiguration);
+        this.body = {
+          text: responseAttributeValue.texts.update,
+          attachments: questionForAttributeConfiguration(nextAttributeConfiguration)
+        };
       } else {
-        this.body = 'Thanks for participating! See you around the Slack.';
+        this.body = `${responseAttributeValue.texts.update} Thanks for participating! See you around the Slack.`;
       }
     }
 

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -53,22 +53,26 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
   });
 
   router.get('/oauth', function* (next) {
-    const requestPromise = new Promise((resolve) => {
-      request
-        .post('https://slack.com/api/oauth.access')
-        .type('form')
-        .send({
-          client_id: process.env.CLIENT_ID,
-          client_secret: process.env.CLIENT_SECRET,
-          code: this.request.query.code
-        })
-        .end((err, res) => {
-          this.body = {test: res.body.bot.bot_access_token};
-          resolve();
-        });
-    });
+    if (this.request.query.code) {
+      const requestPromise = new Promise((resolve) => {
+        request
+          .post('https://slack.com/api/oauth.access')
+          .type('form')
+          .send({
+            client_id: process.env.CLIENT_ID,
+            client_secret: process.env.CLIENT_SECRET,
+            code: this.request.query.code
+          })
+          .end((err, res) => {
+            this.body = {test: res.body.bot.bot_access_token};
+            resolve();
+          });
+      });
 
-    yield requestPromise;
+      yield requestPromise;
+    } else {
+      this.status = 422;
+    }
   });
 
   app.use(router.routes());

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -65,7 +65,7 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
           })
           .end((err, res) => {
             if (res.body.ok) {
-              this.body = {test: res.body.bot.bot_access_token};
+              this.body = {bot_access_token: res.body.bot.bot_access_token};
             } else {
               this.body = {error: res.body.error};
             }

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -38,7 +38,7 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
         })
         .end((err, res) => {
           request.post(payload.response_url).send({
-            attachments: questionForAttributeConfiguration(attributeConfigurations[0]),
+            attachments: [questionForAttributeConfiguration(attributeConfigurations[0])],
             replace_original: false
           }).end();
         });
@@ -62,7 +62,7 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
       if (nextAttributeConfiguration) {
         this.body = {
           text: responseAttributeValue.texts.update,
-          attachments: questionForAttributeConfiguration(nextAttributeConfiguration)
+          attachments: [questionForAttributeConfiguration(nextAttributeConfiguration)]
         };
       } else {
         yield userInformation(userID, {

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -17,7 +17,7 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
     if (attributeName === 'initial') {
       if (action.value === 'yes') {
         this.body = {
-          text: 'Here is the first question???',
+          text: 'Excellent, thank you!',
           attachments: questionForAttributeConfiguration(attributeConfigurations[0])
         };
       } else if (action.value === 'more') {

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -3,6 +3,8 @@ const Router = require('koa-router');
 
 const bodyParser = require('koa-body');
 
+const request = require('superagent');
+
 module.exports = function({attributeConfigurations, questionForAttributeConfiguration, userRepository} = {}) {
   const app = koa();
   app.use(bodyParser());
@@ -48,6 +50,25 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
     }
 
     yield next;
+  });
+
+  router.get('/oauth', function* (next) {
+    const requestPromise = new Promise((resolve) => {
+      request
+        .post('https://slack.com/api/oauth.access')
+        .type('form')
+        .send({
+          client_id: process.env.CLIENT_ID,
+          client_secret: process.env.CLIENT_SECRET,
+          code: this.request.query.code
+        })
+        .end((err, res) => {
+          this.body = {test: res.body.bot.bot_access_token};
+          resolve();
+        });
+    });
+
+    yield requestPromise;
   });
 
   app.use(router.routes());

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -13,7 +13,9 @@ module.exports = function() {
     const payload = JSON.parse(this.request.body.payload);
     const action = payload.actions[0];
 
-    if (action.value === 'more') {
+    if (action.value === 'yes') {
+      this.body = 'Let us continue.';
+    } else if (action.value === 'more') {
       this.body = 'Here is more information.';
     } else {
       this.body = 'Aww!';

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -3,7 +3,7 @@ const Router = require('koa-router');
 
 const bodyParser = require('koa-body');
 
-module.exports = function() {
+module.exports = function({attributeConfigurations, questionForAttributeConfiguration} = {}) {
   const app = koa();
   app.use(bodyParser());
 
@@ -14,7 +14,7 @@ module.exports = function() {
     const action = payload.actions[0];
 
     if (action.value === 'yes') {
-      this.body = 'Let us continue.';
+      this.body = questionForAttributeConfiguration(attributeConfigurations[0]);
     } else if (action.value === 'more') {
       this.body = 'Here is more information.';
     } else {

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -6,6 +6,7 @@ const bodyParser = require('koa-body');
 const request = require('superagent');
 
 const userInformation = require('../reports/user-information');
+const DirectMessageHandler = require('../direct-message-handler');
 
 module.exports = function({attributeConfigurations, questionForAttributeConfiguration, userRepository} = {}) {
   const app = koa();
@@ -27,6 +28,21 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
 
     if (attributeName === 'initial') {
       if (action.value === 'yes') {
+        request.post(payload.response_url).send({
+          text: DirectMessageHandler.INTERVIEW_INTRODUCTION,
+          attachments: [{
+            title: 'Would you like to self-identify?',
+            text: 'Yes'
+          }],
+          replace_original: true
+        })
+        .end((err, res) => {
+          request.post(payload.response_url).send({
+            attachments: questionForAttributeConfiguration(attributeConfigurations[0]),
+            replace_original: false
+          }).end();
+        });
+
         this.body = {
           text: 'Excellent, thank you!',
           attachments: questionForAttributeConfiguration(attributeConfigurations[0])

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -23,7 +23,13 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
         this.body = 'Aww!';
       }
     } else {
-      this.body = questionForAttributeConfiguration(getNextAttributeConfiguration(attributeConfigurations, attributeName));
+      const nextAttributeConfiguration = getNextAttributeConfiguration(attributeConfigurations, attributeName);
+
+      if (nextAttributeConfiguration) {
+        this.body = questionForAttributeConfiguration(nextAttributeConfiguration);
+      } else {
+        this.body = 'Thanks for participating! See you around the Slack.';
+      }
     }
 
     yield next;

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -47,7 +47,7 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
       } else if (action.value === 'more') {
         this.body = 'Here is more information.';
       } else {
-        this.body = 'Aww!';
+        this.body = 'Okay!';
       }
     } else {
       const attributeValueToFind = action.value === 'decline' ? null : action.value;

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -26,12 +26,14 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
         this.body = 'Aww!';
       }
     } else {
+      const attributeValueToFind = action.value === 'decline' ? null : action.value;
+
       const responseAttributeConfiguration = attributeConfigurations.find(configuration => configuration.name === attributeName);
-      const responseAttributeValue = responseAttributeConfiguration.values.find(attributeValue => attributeValue.value === action.value);
+      const responseAttributeValue = responseAttributeConfiguration.values.find(attributeValue => attributeValue.value === attributeValueToFind);
 
       const userID = payload.user.id;
 
-      userRepository.storeAttribute(userID, attributeName, action.value);
+      userRepository.storeAttribute(userID, attributeName, attributeValueToFind);
 
       const nextAttributeConfiguration = getNextAttributeConfiguration(attributeConfigurations, attributeName);
 

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -42,11 +42,6 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
             replace_original: false
           }).end();
         });
-
-        this.body = {
-          text: 'Excellent, thank you!',
-          attachments: questionForAttributeConfiguration(attributeConfigurations[0])
-        };
       } else if (action.value === 'more') {
         this.body = 'Here is more information.';
       } else {

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -5,6 +5,8 @@ const bodyParser = require('koa-body');
 
 const request = require('superagent');
 
+const userInformation = require('../reports/user-information');
+
 module.exports = function({attributeConfigurations, questionForAttributeConfiguration, userRepository} = {}) {
   const app = koa();
   app.use(bodyParser());
@@ -45,7 +47,12 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
           attachments: questionForAttributeConfiguration(nextAttributeConfiguration)
         };
       } else {
-        this.body = `${responseAttributeValue.texts.update} Thanks for participating! See you around the Slack.`;
+        yield userInformation(userID, {
+          userRepository: userRepository,
+          attributeConfigurations: attributeConfigurations
+        }).then(reply => {
+          this.body = `${responseAttributeValue.texts.update} ${reply}\nThanks for participating! See you around the Slack.`;
+        });
       }
     }
 

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -15,6 +15,13 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
 
   router.post('/slack/actions', function* (next) {
     const payload = JSON.parse(this.request.body.payload);
+
+    if (payload.token !== process.env.SLACK_VERIFICATION_TOKEN) {
+      this.status = 403;
+      yield next;
+      return;
+    }
+
     const attributeName = payload.callback_id;
     const action = payload.actions[0];
 

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -1,0 +1,18 @@
+const koa = require('koa');
+const Router = require('koa-router');
+
+module.exports = function() {
+  const app = koa();
+  const router = new Router();
+
+  router.post('/slack/actions', function* (next) {
+    this.body = 'Aww!';
+
+    yield next;
+  });
+
+  app.use(router.routes());
+  app.use(router.allowedMethods());
+
+  return app;
+};

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -11,14 +11,19 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
 
   router.post('/slack/actions', function* (next) {
     const payload = JSON.parse(this.request.body.payload);
+    const attributeName = payload.callback_id;
     const action = payload.actions[0];
 
-    if (action.value === 'yes') {
-      this.body = questionForAttributeConfiguration(attributeConfigurations[0]);
-    } else if (action.value === 'more') {
-      this.body = 'Here is more information.';
+    if (attributeName === 'initial') {
+      if (action.value === 'yes') {
+        this.body = questionForAttributeConfiguration(attributeConfigurations[0]);
+      } else if (action.value === 'more') {
+        this.body = 'Here is more information.';
+      } else {
+        this.body = 'Aww!';
+      }
     } else {
-      this.body = 'Aww!';
+      this.body = questionForAttributeConfiguration(getNextAttributeConfiguration(attributeConfigurations, attributeName));
     }
 
     yield next;
@@ -29,3 +34,8 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
 
   return app;
 };
+
+function getNextAttributeConfiguration(attributeConfigurations, attributeName) {
+  const attributeConfigurationIndex = attributeConfigurations.findIndex(attributeConfiguration => attributeConfiguration.name === attributeName);
+  return attributeConfigurations[attributeConfigurationIndex + 1];
+}

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -60,10 +60,19 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
       const nextAttributeConfiguration = getNextAttributeConfiguration(attributeConfigurations, attributeName);
 
       if (nextAttributeConfiguration) {
-        this.body = {
-          text: responseAttributeValue.texts.update,
-          attachments: [questionForAttributeConfiguration(nextAttributeConfiguration)]
-        };
+        request.post(payload.response_url).send({
+          attachments: [{
+            title: responseAttributeConfiguration.interviewQuestion,
+            text: responseAttributeValue.texts.interviewAnswer
+          }],
+          replace_original: true
+        })
+        .end((err, res) => {
+          request.post(payload.response_url).send({
+            attachments: [questionForAttributeConfiguration(nextAttributeConfiguration)],
+            replace_original: false
+          }).end();
+        });
       } else {
         yield userInformation(userID, {
           userRepository: userRepository,

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -78,7 +78,19 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
           userRepository: userRepository,
           attributeConfigurations: attributeConfigurations
         }).then(reply => {
-          this.body = `${responseAttributeValue.texts.update} ${reply}\nThanks for participating! See you around the Slack.`;
+          request.post(payload.response_url).send({
+            attachments: [{
+              title: responseAttributeConfiguration.interviewQuestion,
+              text: responseAttributeValue.texts.interviewAnswer
+            }],
+            replace_original: true
+          })
+          .end((err, res) => {
+            request.post(payload.response_url).send({
+              text: 'Thanks for participating. See you around the Slack!',
+              replace_original: false
+            }).end();
+          });
         });
       }
     }

--- a/src/message-buttons/server.js
+++ b/src/message-buttons/server.js
@@ -3,7 +3,7 @@ const Router = require('koa-router');
 
 const bodyParser = require('koa-body');
 
-module.exports = function({attributeConfigurations, questionForAttributeConfiguration} = {}) {
+module.exports = function({attributeConfigurations, questionForAttributeConfiguration, userRepository} = {}) {
   const app = koa();
   app.use(bodyParser());
 
@@ -28,6 +28,10 @@ module.exports = function({attributeConfigurations, questionForAttributeConfigur
     } else {
       const responseAttributeConfiguration = attributeConfigurations.find(configuration => configuration.name === attributeName);
       const responseAttributeValue = responseAttributeConfiguration.values.find(attributeValue => attributeValue.value === action.value);
+
+      const userID = payload.user.id;
+
+      userRepository.storeAttribute(userID, attributeName, action.value);
 
       const nextAttributeConfiguration = getNextAttributeConfiguration(attributeConfigurations, attributeName);
 

--- a/src/reports/user-information.js
+++ b/src/reports/user-information.js
@@ -1,0 +1,35 @@
+// FIXME this seems like a bad name/position? Separate into fetching and generating?
+
+const every = require('lodash.every');
+const find = require('lodash.find');
+
+module.exports = function userInformation(userID, {userRepository, attributeConfigurations, helpMessage}) {
+  // FIXME fetch the entire user rather than run multiple queries
+  return Promise.all(attributeConfigurations.map(function(configuration) {
+    return userRepository.retrieveAttribute(userID, configuration.name);
+  })).then(function(values) {
+    var reply;
+
+    if (every(values, function(value) {return value == null || value == undefined})) {
+      reply = `We don’t have you on record! ${helpMessage}`;
+    } else {
+      reply = 'Our records indicate that:\n\n';
+
+      attributeConfigurations.forEach(function(attributeConfiguration, index) {
+        var value = values[index];
+
+        var valueConfiguration = find(attributeConfiguration.values, function(valueConfiguration) {
+          return valueConfiguration.value == value;
+        });
+
+        if (valueConfiguration) {
+          reply += `* ${valueConfiguration.texts.information}\n`;
+        } else {
+          reply += `* ${attributeConfiguration.unknownValue.texts.information}\n`;
+        }
+      });
+    }
+
+    return reply;
+  });
+}

--- a/test/direct-message-handler.js
+++ b/test/direct-message-handler.js
@@ -156,8 +156,9 @@ test('DirectMessageHandler handles an information request', function(t) {
     retrieveAttributeStub.withArgs(person.id, 'manness').returns(Promise.resolve(person.manness));
     retrieveAttributeStub.withArgs(person.id, 'pocness').returns(Promise.resolve(person.pocness));
 
+    // The extra spaces are to verify trimming.
     handler.handle(personIDToChannel[person.id], {
-      text: 'info',
+      text: ' info  ',
       user: person.id
     });
   });
@@ -281,7 +282,7 @@ test('DirectMessageHandler updates channel options and reports them', function(t
       user: admin.id
     });
 
-    setTimeout(() => {      
+    setTimeout(() => {
       t.ok(adminDM.send.calledWithMatch(/<#menexplicitid> has no ignored attributes/), 'expected no ignored attributes to be listed');
 
       t.end();

--- a/test/message-buttons/question-for-attribute-configuration.js
+++ b/test/message-buttons/question-for-attribute-configuration.js
@@ -28,7 +28,7 @@ const attributeConfiguration = {
 };
 
 test('it translates an attribute configuration into a question', function(t) {
-  t.deepEqual(questionForAttributeConfiguration(attributeConfiguration), [{
+  t.deepEqual(questionForAttributeConfiguration(attributeConfiguration), {
     title: 'Do you wear jorts?',
     callback_id: 'jorts',
     color: '#ccc',
@@ -54,7 +54,7 @@ test('it translates an attribute configuration into a question', function(t) {
       type: 'button',
       value: 'decline'
     }]
-  }]);
+  });
 
   t.end();
 });

--- a/test/message-buttons/question-for-attribute-configuration.js
+++ b/test/message-buttons/question-for-attribute-configuration.js
@@ -28,36 +28,33 @@ const attributeConfiguration = {
 };
 
 test('it translates an attribute configuration into a question', function(t) {
-  t.deepEqual(questionForAttributeConfiguration(attributeConfiguration), {
-    text: 'Do you wear jorts?',
-    attachments: [{
-      title: 'Do you wear jorts?',
-      callback_id: 'jorts',
-      color: '#ccc',
-      attachment_type: 'default',
-      actions: [{
-        name: 'jorts',
-        text: 'Yes',
-        type: 'button',
-        value: 'wears jorts'
-      }, {
-        name: 'jorts',
-        text: 'No',
-        type: 'button',
-        value: 'does not wear jorts'
-      }, {
-        name: 'jorts',
-        text: 'Sometimes',
-        type: 'button',
-        value: 'sometimes wears jorts'
-      }, {
-        name: 'jorts',
-        text: 'Decline',
-        type: 'button',
-        value: 'decline'
-      }]
+  t.deepEqual(questionForAttributeConfiguration(attributeConfiguration), [{
+    title: 'Do you wear jorts?',
+    callback_id: 'jorts',
+    color: '#ccc',
+    attachment_type: 'default',
+    actions: [{
+      name: 'jorts',
+      text: 'Yes',
+      type: 'button',
+      value: 'wears jorts'
+    }, {
+      name: 'jorts',
+      text: 'No',
+      type: 'button',
+      value: 'does not wear jorts'
+    }, {
+      name: 'jorts',
+      text: 'Sometimes',
+      type: 'button',
+      value: 'sometimes wears jorts'
+    }, {
+      name: 'jorts',
+      text: 'Decline',
+      type: 'button',
+      value: 'decline'
     }]
-  });
+  }]);
 
   t.end();
 });

--- a/test/message-buttons/question-for-attribute-configuration.js
+++ b/test/message-buttons/question-for-attribute-configuration.js
@@ -31,7 +31,6 @@ test('it translates an attribute configuration into a question', function(t) {
   t.deepEqual(questionForAttributeConfiguration(attributeConfiguration), {
     title: 'Do you wear jorts?',
     callback_id: 'jorts',
-    color: '#ccc',
     attachment_type: 'default',
     actions: [{
       name: 'jorts',

--- a/test/message-buttons/question-for-attribute-configuration.js
+++ b/test/message-buttons/question-for-attribute-configuration.js
@@ -1,0 +1,63 @@
+const test = require('tape');
+const questionForAttributeConfiguration = require('../../src/message-buttons/question-for-attribute-configuration');
+
+const attributeConfiguration = {
+  name: 'jorts',
+  interviewQuestion: 'Do you wear jorts?',
+  values: [{
+    value: 'wears jorts',
+    texts: {
+      interviewAnswer: 'Yes'
+    }
+  }, {
+    value: 'does not wear jorts',
+    texts: {
+      interviewAnswer: 'No'
+    }
+  }, {
+    value: 'sometimes wears jorts',
+    texts: {
+      interviewAnswer: 'Sometimes'
+    }
+  }, {
+    value: null,
+    texts: {
+      interviewAnswer: 'Decline'
+    }
+  }]
+};
+
+test('it translates an attribute configuration into a question', function(t) {
+  t.deepEqual(questionForAttributeConfiguration(attributeConfiguration), {
+    text: 'Do you wear jorts?',
+    attachments: [{
+      title: 'Do you wear jorts?',
+      callback_id: 'jorts',
+      color: '#ccc',
+      attachment_type: 'default',
+      actions: [{
+        name: 'jorts',
+        text: 'Yes',
+        type: 'button',
+        value: 'wears jorts'
+      }, {
+        name: 'jorts',
+        text: 'No',
+        type: 'button',
+        value: 'does not wear jorts'
+      }, {
+        name: 'jorts',
+        text: 'Sometimes',
+        type: 'button',
+        value: 'sometimes wears jorts'
+      }, {
+        name: 'jorts',
+        text: 'Decline',
+        type: 'button',
+        value: 'decline'
+      }]
+    }]
+  });
+
+  t.end();
+});

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -194,6 +194,17 @@ test('it responds to an OAuth request with the bot access token', function(t) {
     .expect(200, (err, res) => {
       t.notOk(err, 'expected no error');
       t.equal(res.body.test, 'yesthisisthestring');
+
+      nock.cleanAll();
+      t.end();
+    });
+});
+
+test('it responds to an OAuth request lacking a code with an error', function(t) {
+  agent(startServer())
+    .get('/oauth')
+    .type('form')
+    .expect(422, (err, res) => {
       t.end();
     });
 });

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -194,7 +194,7 @@ test('it responds to an OAuth request with the bot access token', function(t) {
     })
     .expect(200, (err, res) => {
       t.notOk(err, 'expected no error');
-      t.equal(res.body.test, 'yesthisisthestring');
+      t.equal(res.body.bot_access_token, 'yesthisisthestring');
 
       nock.cleanAll();
       t.end();

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -71,6 +71,20 @@ test('it handles a response to the first attribute question by asking the second
     .expect(200, 'jantsQuestion', t.end);
 });
 
+test('it handles a response to the last attribute question by thanking and wrapping up', function(t) {
+  agent(startServer({attributeConfigurations, questionForAttributeConfiguration}))
+    .post('/slack/actions')
+    .type('form')
+    .send({payload: JSON.stringify({
+      callback_id: 'jants',
+      actions: [{
+        name: 'yes',
+        value: 'yes'
+      }]
+    })})
+    .expect(200, 'Thanks for participating! See you around the Slack.', t.end);
+});
+
 test('it handles a more information request from the initial interview question', function(t) {
   agent(startServer())
     .post('/slack/actions')

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -4,6 +4,20 @@ const agent = require('supertest-koa-agent');
 const test = require('tape');
 const sinon = require('sinon');
 
+test('it handles a more information request from the initial interview question', function(t) {
+  agent(startServer())
+    .post('/slack/actions')
+    .type('form')
+    .send({payload: JSON.stringify({
+      callback_id: 'initial',
+      actions: [{
+        name: 'more',
+        value: 'more'
+      }]
+    })})
+    .expect(200, 'Here is more information.', t.end);
+});
+
 test('it handles a rejection of the initial interview question', function(t) {
   agent(startServer())
     .post('/slack/actions')

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -288,7 +288,7 @@ test('it handles a rejection of the initial interview question', function(t) {
       }],
       token: 'a-verification-token'
     })})
-    .expect(200, 'Aww!', t.end);
+    .expect(200, 'Okay!', t.end);
 });
 
 test('it rejects an action without the correct verification token', function(t) {

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -170,3 +170,30 @@ test('it handles a rejection of the initial interview question', function(t) {
     })})
     .expect(200, 'Aww!', t.end);
 });
+
+test('it responds to an OAuth request with the bot access token', function(t) {
+  const nock = require('nock');
+
+  process.env.CLIENT_ID = 'client-id';
+  process.env.CLIENT_SECRET = 'client-secret';
+
+  nock('https://slack.com')
+    .post('/api/oauth.access', 'client_id=client-id&client_secret=client-secret&code=a-code')
+    .reply(200, {
+      bot: {
+        bot_access_token: 'yesthisisthestring'
+      }
+    });
+
+  agent(startServer())
+    .get('/oauth')
+    .type('form')
+    .query({
+      code: 'a-code'
+    })
+    .expect(200, (err, res) => {
+      t.notOk(err, 'expected no error');
+      t.equal(res.body.test, 'yesthisisthestring');
+      t.end();
+    });
+});

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -169,7 +169,7 @@ test('it handles a response to the first attribute question by storing it and as
       }],
       token: 'a-verification-token'
     })})
-    .expect(200, (err, {res: body}) => {
+    .expect(200, () => {
       t.ok(storeAttributeStub.calledWith('userID', 'jorts', 'wears jorts'), 'stores the attribute value');
       storeAttributeStub.restore();
     });
@@ -255,7 +255,7 @@ test('it handles a response to the last attribute question by storing it, repeat
       }],
       token: 'a-verification-token'
     })})
-    .expect(200, (err, {res: body}) => {
+    .expect(200, () => {
       t.ok(storeAttributeStub.calledWith('userID', 'jants', 'does not wear jants'), 'stores the attribute value');
       storeAttributeStub.restore();
     });

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -136,7 +136,7 @@ test('it handles a response to the first attribute question by storing it and as
     })})
     .expect(200, (err, {res: body}) => {
       t.deepEqual(body.body, {text: 'We have noted that you wear jorts.', attachments: ['jantsQuestion']});
-      t.ok(storeAttributeStub.calledWith('userID', 'jorts', 'wears jorts'));
+      t.ok(storeAttributeStub.calledWith('userID', 'jorts', 'wears jorts'), 'stores the attribute value');
       storeAttributeStub.restore();
       t.end();
     });
@@ -160,7 +160,7 @@ test('it handles a decline response to the first attribute question by storing i
       token: 'a-verification-token'
     })})
     .expect(200, () => {
-      t.ok(storeAttributeStub.calledWith('userID', 'jorts', null));
+      t.ok(storeAttributeStub.calledWith('userID', 'jorts', null), 'clears the attribute value');
       storeAttributeStub.restore();
       t.end();
     });
@@ -189,7 +189,7 @@ test('it handles a response to the last attribute question by storing it, summar
     })})
     .expect(200, (err, {res: body}) => {
       t.equal(body.text, 'We have noted that you do not wear jants. Our records indicate that:\n\n* you wear jorts\n* you do not wear jants\n\nThanks for participating! See you around the Slack.');
-      t.ok(storeAttributeStub.calledWith('userID', 'jants', 'does not wear jants'));
+      t.ok(storeAttributeStub.calledWith('userID', 'jants', 'does not wear jants'), 'stores the attribute value');
       storeAttributeStub.restore();
       t.end();
     });

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -1,0 +1,19 @@
+const startServer = require('../../src/message-buttons/server');
+const agent = require('supertest-koa-agent');
+
+const test = require('tape');
+const sinon = require('sinon');
+
+test('it handles a rejection of the initial interview question', function(t) {
+  agent(startServer())
+    .post('/slack/actions')
+    .type('form')
+    .send({payload: JSON.stringify({
+      callback_id: 'initial',
+      actions: [{
+        name: 'no',
+        value: 'no'
+      }]
+    })})
+    .expect(200, 'Aww!', t.end);
+});

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -67,7 +67,7 @@ test('it handles acceptance of the initial interview question by responding with
         value: 'yes'
       }]
     })})
-    .expect(200, {text: 'Here is the first question???', attachments: 'jortsQuestion'}, t.end);
+    .expect(200, {text: 'Excellent, thank you!', attachments: 'jortsQuestion'}, t.end);
 });
 
 test('it handles a response to the first attribute question by asking the second attribute question', function(t) {

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -97,6 +97,29 @@ test('it handles a response to the first attribute question by storing it and as
     });
 });
 
+test('it handles a decline response to the first attribute question by storing it as null', function(t) {
+  const storeAttributeStub = sinon.stub(fakeUserRepository, 'storeAttribute');
+
+  agent(startServer({attributeConfigurations, questionForAttributeConfiguration, userRepository: fakeUserRepository}))
+    .post('/slack/actions')
+    .type('form')
+    .send({payload: JSON.stringify({
+      callback_id: 'jorts',
+      user: {
+        id: 'userID'
+      },
+      actions: [{
+        name: 'irrelevant',
+        value: 'decline'
+      }]
+    })})
+    .expect(200, () => {
+      t.ok(storeAttributeStub.calledWith('userID', 'jorts', null));
+      storeAttributeStub.restore();
+      t.end();
+    });
+});
+
 test('it handles a response to the last attribute question by storing it and thanking and wrapping up', function(t) {
   const storeAttributeStub = sinon.stub(fakeUserRepository, 'storeAttribute');
 

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -30,12 +30,17 @@ const firstAttributeConfiguration = {
   }]
 };
 
+const secondAttributeConfiguration = {
+  name: 'jants'
+};
+
 const attributeConfigurations = [
-  firstAttributeConfiguration
+  firstAttributeConfiguration,
+  secondAttributeConfiguration
 ];
 
-function questionForAttributeConfiguration() {
-  return 'a question';
+function questionForAttributeConfiguration(attributeConfiguration) {
+  return `${attributeConfiguration.name}Question`;
 }
 
 test('it handles acceptance of the initial interview question by responding with a question for the first attribute', function(t) {
@@ -49,7 +54,21 @@ test('it handles acceptance of the initial interview question by responding with
         value: 'yes'
       }]
     })})
-    .expect(200, questionForAttributeConfiguration(), t.end);
+    .expect(200, 'jortsQuestion', t.end);
+});
+
+test('it handles a response to the first attribute question by asking the second attribute question', function(t) {
+  agent(startServer({attributeConfigurations, questionForAttributeConfiguration}))
+    .post('/slack/actions')
+    .type('form')
+    .send({payload: JSON.stringify({
+      callback_id: 'jorts',
+      actions: [{
+        name: 'yes',
+        value: 'yes'
+      }]
+    })})
+    .expect(200, 'jantsQuestion', t.end);
 });
 
 test('it handles a more information request from the initial interview question', function(t) {

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -4,6 +4,20 @@ const agent = require('supertest-koa-agent');
 const test = require('tape');
 const sinon = require('sinon');
 
+test('it handles acceptance of the initial interview question', function(t) {
+  agent(startServer())
+    .post('/slack/actions')
+    .type('form')
+    .send({payload: JSON.stringify({
+      callback_id: 'initial',
+      actions: [{
+        name: 'yes',
+        value: 'yes'
+      }]
+    })})
+    .expect(200, 'Let us continue.', t.end);
+});
+
 test('it handles a more information request from the initial interview question', function(t) {
   agent(startServer())
     .post('/slack/actions')

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -90,7 +90,8 @@ test('it handles a response to the first attribute question by storing it and as
         value: 'wears jorts'
       }]
     })})
-    .expect(200, {text: 'We have noted that you wear jorts.', attachments: 'jantsQuestion'}, () => {
+    .expect(200, (err, {res: body}) => {
+      t.deepEqual(body.body, {text: 'We have noted that you wear jorts.', attachments: 'jantsQuestion'});
       t.ok(storeAttributeStub.calledWith('userID', 'jorts', 'wears jorts'));
       storeAttributeStub.restore();
       t.end();
@@ -136,7 +137,8 @@ test('it handles a response to the last attribute question by storing it and tha
         value: 'does not wear jants'
       }]
     })})
-    .expect(200, 'We have noted that you do not wear jants. Thanks for participating! See you around the Slack.', () => {
+    .expect(200, (err, {res: body}) => {
+      t.equal(body.text, 'We have noted that you do not wear jants. Thanks for participating! See you around the Slack.');
       t.ok(storeAttributeStub.calledWith('userID', 'jants', 'does not wear jants'));
       storeAttributeStub.restore();
       t.end();

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -145,7 +145,7 @@ test('it handles a response to the last attribute question by storing it, summar
       }]
     })})
     .expect(200, (err, {res: body}) => {
-      t.equal(body.text, 'We have noted that you do not wear jants. To summarise:\n* you wear jorts* you do not wear jants\n\nThanks for participating! See you around the Slack.');
+      t.equal(body.text, 'We have noted that you do not wear jants. Our records indicate that:\n\n* you wear jorts\n* you do not wear jants\n\nThanks for participating! See you around the Slack.');
       t.ok(storeAttributeStub.calledWith('userID', 'jants', 'does not wear jants'));
       storeAttributeStub.restore();
       t.end();

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -92,7 +92,7 @@ test('it handles acceptance of the initial interview question by repeating the q
         }, 'should restate the question with the answer attached');
 
         t.deepEqual(secondResponse, {
-          attachments: 'jortsQuestion',
+          attachments: ['jortsQuestion'],
           replace_original: false
         }, 'should follow up with the first attribute question');
 
@@ -135,7 +135,7 @@ test('it handles a response to the first attribute question by storing it and as
       token: 'a-verification-token'
     })})
     .expect(200, (err, {res: body}) => {
-      t.deepEqual(body.body, {text: 'We have noted that you wear jorts.', attachments: 'jantsQuestion'});
+      t.deepEqual(body.body, {text: 'We have noted that you wear jorts.', attachments: ['jantsQuestion']});
       t.ok(storeAttributeStub.calledWith('userID', 'jorts', 'wears jorts'));
       storeAttributeStub.restore();
       t.end();

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -10,7 +10,8 @@ const firstAttributeConfiguration = {
   values: [{
     value: 'wears jorts',
     texts: {
-      interviewAnswer: 'Yes'
+      interviewAnswer: 'Yes',
+      update: 'We have noted that you wear jorts.'
     }
   }, {
     value: 'does not wear jorts',
@@ -31,7 +32,19 @@ const firstAttributeConfiguration = {
 };
 
 const secondAttributeConfiguration = {
-  name: 'jants'
+  name: 'jants',
+  interviewQuestion: 'Do you wear jants?',
+  values: [{
+    value: 'wears jants',
+    texts: {
+      interviewAnswer: 'Yes'
+    }
+  }, {
+    value: 'does not wear jants',
+    texts: {
+      update: 'We have noted that you do not wear jants.'
+    }
+  }]
 };
 
 const attributeConfigurations = [
@@ -54,7 +67,7 @@ test('it handles acceptance of the initial interview question by responding with
         value: 'yes'
       }]
     })})
-    .expect(200, 'jortsQuestion', t.end);
+    .expect(200, {text: 'Here is the first question???', attachments: 'jortsQuestion'}, t.end);
 });
 
 test('it handles a response to the first attribute question by asking the second attribute question', function(t) {
@@ -65,10 +78,10 @@ test('it handles a response to the first attribute question by asking the second
       callback_id: 'jorts',
       actions: [{
         name: 'yes',
-        value: 'yes'
+        value: 'wears jorts'
       }]
     })})
-    .expect(200, 'jantsQuestion', t.end);
+    .expect(200, {text: 'We have noted that you wear jorts.', attachments: 'jantsQuestion'}, t.end);
 });
 
 test('it handles a response to the last attribute question by thanking and wrapping up', function(t) {
@@ -78,11 +91,11 @@ test('it handles a response to the last attribute question by thanking and wrapp
     .send({payload: JSON.stringify({
       callback_id: 'jants',
       actions: [{
-        name: 'yes',
-        value: 'yes'
+        name: 'irrelevant',
+        value: 'does not wear jants'
       }]
     })})
-    .expect(200, 'Thanks for participating! See you around the Slack.', t.end);
+    .expect(200, 'We have noted that you do not wear jants. Thanks for participating! See you around the Slack.', t.end);
 });
 
 test('it handles a more information request from the initial interview question', function(t) {

--- a/test/message-buttons/server.js
+++ b/test/message-buttons/server.js
@@ -4,8 +4,42 @@ const agent = require('supertest-koa-agent');
 const test = require('tape');
 const sinon = require('sinon');
 
-test('it handles acceptance of the initial interview question', function(t) {
-  agent(startServer())
+const firstAttributeConfiguration = {
+  name: 'jorts',
+  interviewQuestion: 'Do you wear jorts?',
+  values: [{
+    value: 'wears jorts',
+    texts: {
+      interviewAnswer: 'Yes'
+    }
+  }, {
+    value: 'does not wear jorts',
+    texts: {
+      interviewAnswer: 'No'
+    }
+  }, {
+    value: 'sometimes wears jorts',
+    texts: {
+      interviewAnswer: 'Sometimes'
+    }
+  }, {
+    value: null,
+    texts: {
+      interviewAnswer: 'Decline'
+    }
+  }]
+};
+
+const attributeConfigurations = [
+  firstAttributeConfiguration
+];
+
+function questionForAttributeConfiguration() {
+  return 'a question';
+}
+
+test('it handles acceptance of the initial interview question by responding with a question for the first attribute', function(t) {
+  agent(startServer({attributeConfigurations, questionForAttributeConfiguration}))
     .post('/slack/actions')
     .type('form')
     .send({payload: JSON.stringify({
@@ -15,7 +49,7 @@ test('it handles acceptance of the initial interview question', function(t) {
         value: 'yes'
       }]
     })})
-    .expect(200, 'Let us continue.', t.end);
+    .expect(200, questionForAttributeConfiguration(), t.end);
 });
 
 test('it handles a more information request from the initial interview question', function(t) {

--- a/web.js
+++ b/web.js
@@ -1,0 +1,6 @@
+const attributeConfigurations = require('./attribute-configurations');
+const questionForAttributeConfiguration = require('src/message-buttons/question-for-attribute-configuration');
+
+const server = require('./src/message-buttons/server')({attributeConfiguration, questionForAttributeConfiguration});
+
+server.listen(process.env.PORT || 3000);

--- a/web.js
+++ b/web.js
@@ -1,6 +1,6 @@
-const attributeConfigurations = require('./attribute-configurations');
-const questionForAttributeConfiguration = require('src/message-buttons/question-for-attribute-configuration');
+const attributeConfigurations = require('./src/attribute-configurations');
+const questionForAttributeConfiguration = require('./src/message-buttons/question-for-attribute-configuration');
 
-const server = require('./src/message-buttons/server')({attributeConfiguration, questionForAttributeConfiguration});
+const server = require('./src/message-buttons/server')({attributeConfigurations, questionForAttributeConfiguration});
 
 server.listen(process.env.PORT || 3000);

--- a/web.js
+++ b/web.js
@@ -1,6 +1,10 @@
 const attributeConfigurations = require('./src/attribute-configurations');
 const questionForAttributeConfiguration = require('./src/message-buttons/question-for-attribute-configuration');
 
-const server = require('./src/message-buttons/server')({attributeConfigurations, questionForAttributeConfiguration});
+const UserRepository = require('./src/persistence/user-repository');
+const db = require('./models');
+const userRepository = new UserRepository(db.User);
+
+const server = require('./src/message-buttons/server')({attributeConfigurations, questionForAttributeConfiguration, userRepository});
 
 server.listen(process.env.PORT || 3000);


### PR DESCRIPTION
Here is some progress toward message buttons for setting attributes.

A GIF of it in action:
![bot-message-boxes](https://cloud.githubusercontent.com/assets/43280/16710954/4e8b5b48-4609-11e6-8312-c98408415401.gif)

It doesn’t actually update the database 😁 but that shouldn’t be _too_ hard
